### PR TITLE
add standalone visualizer v1

### DIFF
--- a/auto_causality/visualizer.py
+++ b/auto_causality/visualizer.py
@@ -1,0 +1,264 @@
+import math
+from typing import Optional, Dict, Union, Any, List, Tuple, Literal
+
+import numpy as np
+import pandas as pd
+
+import matplotlib
+import matplotlib.pyplot as plt
+
+from auto_causality.shap import shap
+from auto_causality.models.dummy import PropensityScoreWeighter
+
+
+# TODO: decide on how Visualizer and AutoCausality should interact; 
+#       currently standalone and mimicking some methods from auto-causality
+# TODO: make plots themselves a bit nicer and allow for more flexibility/customization
+# TODO: (?) write tests
+
+class Visualizer:
+
+    def __init__(
+        self,
+        test_df: pd.DataFrame,
+        treatment_col_name: str,
+        outcome_col_name: str,
+                 
+    ) -> None:
+        
+        assert treatment_col_name and outcome_col_name in test_df.columns, 'Check that treatment and outcome columns are specified correctly.'
+        
+        self.test_df = test_df
+        self.treatment_col_name = treatment_col_name
+        self.outcome_col_name = outcome_col_name
+        self.t_list = [int(t) for t in sorted(list(self.test_df[self.treatment_col_name].unique()))]
+
+
+    # TODO: make this a bit nicer
+    def plot_shap(
+        self,
+        shapley_values: np.ndarray,
+        df: pd.DataFrame,
+        effect_modifier_names: List,
+        figtitle: str = ""         
+    
+    ) -> None:
+        
+        assert len(effect_modifier_names) == shapley_values.shape[1], "Column mismatch."
+        
+        plt.title(figtitle)
+        shap.summary_plot(shapley_values, df[effect_modifier_names])
+        plt.show()
+
+
+    def plot_metrics_by_estimator(
+        self,
+        scores_dict: Dict,
+        figtitle: str = "",
+        metrics: Tuple[str, str] = ('norm_erupt', 'ate'),
+        figsize: Tuple[int, int] = (7,5),
+        
+    ) -> None:
+        
+        """
+        Plot metrics by estimator.
+
+        @param scores_dict: scores dict from fitted auto-causality object;
+        @param figtitle: str to specify plot title, defaults to "";
+        @param metrics: tuple specifying metrics, defaults to ('norm_erupt', 'ate');
+        @param figsize: tuple specifying plot size, defaults to (7,5);
+        
+        """
+        
+        colors = ([matplotlib.colors.CSS4_COLORS['black']] +
+            list(matplotlib.colors.TABLEAU_COLORS) + [
+            matplotlib.colors.CSS4_COLORS['lime'],
+            matplotlib.colors.CSS4_COLORS['yellow'],
+            matplotlib.colors.CSS4_COLORS['pink']
+        ])
+
+
+        plt.figure(figsize = figsize)
+        plt.title(figtitle)
+
+        m1 = metrics[1]
+        m2 = metrics[0]
+
+        for (est, scr), col in zip(scores_dict.items(),colors):
+            try:
+                sc = [scr["scores"]['train'][m1], scr["scores"]['validation'][m1], scr["scores"]['test'][m1]]
+                crv = [scr["scores"]['train'][m2], scr["scores"]['validation'][m2], scr["scores"]['test'][m2]]
+                plt.plot(sc, crv, color=col, marker="o", label=est)
+                plt.scatter(sc[1:2],crv[1:2], c=col, s=70, label="_nolegend_" )
+                plt.scatter(sc[2:],crv[2:], c=col, s=120, label="_nolegend_" )
+
+            except:
+                pass
+        plt.xlabel(m1)
+        plt.ylabel(m2)
+
+        plt.legend(bbox_to_anchor=(1.04,1), borderaxespad=0)
+        plt.annotate('By size (ascending): train/val/test', (0,0), (0, -40), xycoords='axes fraction', textcoords='offset points', va='top')
+
+        plt.grid()
+        plt.show()
+        
+
+    def plot_group_ate(
+        self,
+        policy_df: pd.DataFrame,
+        psw: PropensityScoreWeighter,
+        single_t: str = ''
+
+    ) -> Dict:
+        
+        """
+        Plot group ate per treatment.
+
+        @param policy_df: pd.DataFrame with cols T, Y, policy_T_1, policy_T_2 etc., policy cols being bool;
+        @param psw: PropensityScoreWeighter from auto-causality;
+        @param single_t: if set to specific treatment, only plot group ate for this treatment; defaults to '' to generate joint plot;
+        
+        @return all_grps: Dict containing treatments as keys and group ate dataframes as values;
+        
+        """
+        
+        assert self.treatment_col_name and self.outcome_col_name in policy_df.columns, f"Please add columns {self.treatment_col_name} and {self.outcome_col_name} to your policy dataframe."
+        assert self.test_df[self.treatment_col_name].nunique()-1 == len(policy_df.columns)-2, f'Mismatch between number of treatments ({self.test_df[self.treatment_col_name].nunique()-1}) and supplied policies ({len(policy_df.columns)-2}).'
+
+        # obtain group ate df for every treatment
+        all_grps = {}
+        for t in policy_df.columns:
+            if t not in [self.treatment_col_name, self.outcome_col_name]:
+                t_pol = policy_df[(policy_df[self.treatment_col_name] == int(t)) | (policy_df[self.treatment_col_name] == 0)][[t]]
+                t_pol.reset_index(inplace=True)
+                all_grps[t] = self.calculate_group_ate(t, t_pol, psw)
+
+
+        # re-shuffle initial dict for plotting
+        tmp = pd.DataFrame(columns=['policy', 'mean', 'std', 'count'])
+        for v in all_grps.values():
+            tmp = pd.concat([tmp, v],ignore_index=True)
+
+        d = {}
+        for p in tmp['policy'].unique():
+            d[p] = {'mean': [], 'std': []}
+            _ = tmp[tmp['policy']==p]
+            for m in ['mean', 'std']:
+                d[p][m] = _[m].values
+        
+        # actual plotting
+        if single_t == '':
+            self.__plot_multi_ate(grp_dict=all_grps, plot_dict=d)
+        else:
+            self.__plot_single_ate(grp_dict=all_grps, single_t=single_t)
+
+
+        return all_grps
+
+
+
+    def __plot_multi_ate(
+        self,
+        grp_dict: Dict,
+        plot_dict: Dict
+    ):
+        X = [str(t) for t in grp_dict.keys()]
+        plt.figure(figsize=(3*len(X),6))
+
+        if not False:
+            m, c, b = plt.errorbar(X, plot_dict['False']['mean'], yerr=plot_dict['False']['std'], color='blue', fmt='o', elinewidth=3)
+            [bar.set_alpha(0.5) for bar in b]
+            m, c, b = plt.errorbar(X, plot_dict['True']['mean'], yerr=plot_dict['True']['std'], color='red', fmt='o', elinewidth=3 )
+            [bar.set_alpha(0.5) for bar in b]
+
+            plt.legend(['True', 'False'], loc='best')
+
+        # TODO: make this actually work
+        else:
+            m, c, b = plt.errorbar(X, plot_dict['all']['mean'], yerr=plot_dict['all']['std'], color='black', fmt='o', elinewidth=3 )
+            [bar.set_alpha(0.5) for bar in b]
+
+            plt.legend(['all'], loc='best')
+
+        plt.grid()
+        # plt.title('test')    
+        plt.xlabel('Treatment')
+        plt.ylabel('Group ATE')
+        plt.show()
+
+    def __plot_single_ate(
+        self,
+        grp_dict: Dict,
+        single_t: str
+
+    ):
+    
+        s_t = grp_dict[single_t]
+        grp = s_t["policy"].unique()
+
+        colors = (matplotlib.colors.CSS4_COLORS['black'],
+                matplotlib.colors.CSS4_COLORS['red'],
+                matplotlib.colors.CSS4_COLORS['blue'])
+
+        for i,(p,c) in enumerate(zip(grp, colors)):
+            st = s_t[s_t["policy"] == p]
+            plt.errorbar(np.array(range(len(st))) +0.1*i, st["mean"].values[0],  yerr = st["std"].values[0], fmt='o', color=c)
+        plt.legend(grp)
+        plt.grid(True)
+        plt.ylabel('Group ATE')
+        plt.xticks([])
+        plt.title(f'Treatment {single_t}')
+        plt.show()
+    
+
+    # mimic ac.scorer.group_ate method
+    def calculate_group_ate(
+        self,
+        t: int,
+        t_pol: pd.DataFrame,
+        psw: PropensityScoreWeighter
+    ):
+        
+        t_df = self.test_df[(self.test_df[self.treatment_col_name] == int(t)) | (self.test_df[self.treatment_col_name] == 0)]
+        t_df.reset_index(inplace=True)
+        tmp = {'all': self.ate(t_df, psw)}
+
+        for p in sorted(list(t_pol[t].unique())):
+            tmp[p] = self.ate(t_df[t_pol[t] == p], psw)
+
+        tmp2 = [
+            {"policy": str(p), "mean": m, "std": s, "count": c}
+            for p, (m, s, c) in tmp.items()
+        ]
+
+        return pd.DataFrame(tmp2)
+ 
+    # mimic ac.scorer.ate method, but adjusting it slightly for multi-t
+    def ate(
+        self, 
+        t_df: pd.DataFrame,
+        psw: PropensityScoreWeighter
+    ):
+        
+        estimate = np.nanmax(psw.effect(t_df).mean(axis=0))
+        naive_est = self.naive_ate(t_df[self.treatment_col_name], t_df[self.outcome_col_name])
+
+        return estimate, naive_est[1], naive_est[2]
+
+    # mimic naive_ate function for sneaky std calc
+    def naive_ate(
+        self,
+        t_col: pd.Series,
+        o_col: pd.Series
+    ):
+        
+        treated = (t_col > 0).sum()
+        
+        mean_ = o_col[t_col > 0].mean() - o_col[t_col == 0].mean()
+        std1 = o_col[t_col > 0].std() / (math.sqrt(treated) + 1e-3)
+        std2 = o_col[t_col == 0].std() / (
+            math.sqrt(len(o_col) - treated) + 1e-3
+        )
+        std_ = math.sqrt(std1 * std1 + std2 * std2)
+        return (mean_, std_, len(t_col))

--- a/notebooks/Random assignment, binary CATE example.ipynb
+++ b/notebooks/Random assignment, binary CATE example.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "b6eaac69",
    "metadata": {
     "pycharm": {
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "53241021",
    "metadata": {
     "pycharm": {
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "5ed9b5f7",
    "metadata": {
     "pycharm": {
@@ -94,13 +94,7 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": [
-       "\n",
-       "// turn off scrollable windows for large output\n",
-       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
-       "    return false;\n",
-       "}\n"
-      ],
+      "application/javascript": "\n// turn off scrollable windows for large output\nIPython.OutputArea.prototype._should_scroll = function(lines) {\n    return false;\n}\n",
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -120,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "da208ce6",
    "metadata": {
     "pycharm": {
@@ -131,8 +125,8 @@
    "source": [
     "from auto_causality import AutoCausality\n",
     "from auto_causality.datasets import synth_ihdp\n",
-    "from auto_causality.data_utils import preprocess_dataset\n",
-    "from auto_causality.scoring import Scorer"
+    "from auto_causality.data_utils import CausalityDataset\n",
+    "from auto_causality.visualizer import Visualizer"
    ]
   },
   {
@@ -154,28 +148,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "id": "4a0751bf",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "data = synth_ihdp()\n",
-    "treatment = data.treatment\n",
-    "targets = data.outcomes\n",
-    "data_df, features_X, features_W = preprocess_dataset(data.data, treatment, targets)\n",
-    "\n",
-    "outcome = targets[0]\n",
-    "train_df, test_df = train_test_split(data_df, test_size=0.2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "49e4721b",
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -183,36 +157,210 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     treatment  y_factual        x1        x2        x3        x4        x5  \\\n",
-      "262        1.0   6.886719  0.467901  0.196818  0.383828  0.161703 -0.941775   \n",
-      "211        0.0   5.027350  0.748911  0.596582 -0.360898 -0.879606 -1.191844   \n",
-      "413        0.0   3.144238 -0.158967 -0.202946  0.011465 -0.879606 -0.066534   \n",
-      "376        0.0   1.792748  1.246082  0.996346 -0.360898  0.161703 -2.004568   \n",
-      "230        0.0   2.771920 -1.218158 -1.802002  2.245643 -0.879606 -0.254086   \n",
-      "\n",
-      "           x6   x7   x8  ...  x17  x18  x19  x20  x21  x22  x23  x24  x25  \\\n",
-      "262 -1.189018  1.0  0.0  ...  0.0  1.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0   \n",
-      "211  1.129600  1.0  0.0  ...  1.0  1.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0   \n",
-      "413 -1.851480  0.0  0.0  ...  0.0  1.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0   \n",
-      "376 -0.526556  0.0  0.0  ...  1.0  1.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0   \n",
-      "230  0.467138  1.0  0.0  ...  1.0  1.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0   \n",
-      "\n",
-      "     random  \n",
-      "262     1.0  \n",
-      "211     0.0  \n",
-      "413     0.0  \n",
-      "376     1.0  \n",
-      "230     0.0  \n",
-      "\n",
-      "[5 rows x 28 columns]\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>treatment</th>\n",
+       "      <th>y_factual</th>\n",
+       "      <th>x1</th>\n",
+       "      <th>x2</th>\n",
+       "      <th>x3</th>\n",
+       "      <th>x4</th>\n",
+       "      <th>x5</th>\n",
+       "      <th>x6</th>\n",
+       "      <th>x7</th>\n",
+       "      <th>x8</th>\n",
+       "      <th>...</th>\n",
+       "      <th>x17</th>\n",
+       "      <th>x18</th>\n",
+       "      <th>x19</th>\n",
+       "      <th>x20</th>\n",
+       "      <th>x21</th>\n",
+       "      <th>x22</th>\n",
+       "      <th>x23</th>\n",
+       "      <th>x24</th>\n",
+       "      <th>x25</th>\n",
+       "      <th>random</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>5.599916</td>\n",
+       "      <td>-0.528603</td>\n",
+       "      <td>-0.343455</td>\n",
+       "      <td>1.128554</td>\n",
+       "      <td>0.161703</td>\n",
+       "      <td>-0.316603</td>\n",
+       "      <td>1.295216</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>6.875856</td>\n",
+       "      <td>-1.736945</td>\n",
+       "      <td>-1.802002</td>\n",
+       "      <td>0.383828</td>\n",
+       "      <td>2.244320</td>\n",
+       "      <td>-0.629189</td>\n",
+       "      <td>1.295216</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>2.996273</td>\n",
+       "      <td>-0.807451</td>\n",
+       "      <td>-0.202946</td>\n",
+       "      <td>-0.360898</td>\n",
+       "      <td>-0.879606</td>\n",
+       "      <td>0.808706</td>\n",
+       "      <td>-0.526556</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1.366206</td>\n",
+       "      <td>0.390083</td>\n",
+       "      <td>0.596582</td>\n",
+       "      <td>-1.850350</td>\n",
+       "      <td>-0.879606</td>\n",
+       "      <td>-0.004017</td>\n",
+       "      <td>-0.857787</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1.963538</td>\n",
+       "      <td>-1.045229</td>\n",
+       "      <td>-0.602710</td>\n",
+       "      <td>0.011465</td>\n",
+       "      <td>0.161703</td>\n",
+       "      <td>0.683672</td>\n",
+       "      <td>-0.360940</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 28 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   treatment  y_factual        x1        x2        x3        x4        x5  \\\n",
+       "0          1   5.599916 -0.528603 -0.343455  1.128554  0.161703 -0.316603   \n",
+       "1          0   6.875856 -1.736945 -1.802002  0.383828  2.244320 -0.629189   \n",
+       "2          0   2.996273 -0.807451 -0.202946 -0.360898 -0.879606  0.808706   \n",
+       "3          0   1.366206  0.390083  0.596582 -1.850350 -0.879606 -0.004017   \n",
+       "4          0   1.963538 -1.045229 -0.602710  0.011465  0.161703  0.683672   \n",
+       "\n",
+       "         x6  x7  x8  ...  x17  x18  x19  x20  x21  x22  x23  x24  x25  random  \n",
+       "0  1.295216   1   0  ...    1    1    1    0    0    0    0    0    0       0  \n",
+       "1  1.295216   0   0  ...    1    1    1    0    0    0    0    0    0       1  \n",
+       "2 -0.526556   0   0  ...    0    1    1    0    0    0    0    0    0       1  \n",
+       "3 -0.857787   0   0  ...    0    1    1    0    0    0    0    0    0       1  \n",
+       "4 -0.360940   1   0  ...    1    1    1    0    0    0    0    0    0       1  \n",
+       "\n",
+       "[5 rows x 28 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "print(train_df.head())"
+    "data = synth_ihdp()\n",
+    "display(data.data.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "429f47d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.preprocess_dataset()"
    ]
   },
   {
@@ -234,6 +382,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "ac = AutoCausality(\n",
@@ -254,12 +408,12 @@
     "    metric=\"norm_erupt\",\n",
     "    verbose=3,\n",
     "    components_verbose=2,\n",
-    "    components_time_budget=600,\n",
+    "    components_time_budget=10,\n",
     ")\n",
     "\n",
     "\n",
     "# run autocausality\n",
-    "ac.fit(train_df, treatment, outcome, features_W, features_X)\n",
+    "ac.fit(data)\n",
     "\n",
     "# return best estimator\n",
     "print(f\"Best estimator: {ac.best_estimator}\")\n",
@@ -267,29 +421,29 @@
     "print(f\"best config: {ac.best_config}\")\n",
     "# best score:\n",
     "print(f\"best score: {ac.best_score}\")\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "After running a fit, you can resume it without losing past results, for example if you want to search over extra estimators."
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "After running a fit, you can resume it without losing past results, for example if you want to search over extra estimators."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# we can now resume the fit to continue with the init_cfgs which we haven't tried yet\n",
@@ -300,48 +454,93 @@
     "# print(f\"best config: {ac.best_config}\")\n",
     "# # best score:\n",
     "# print(f\"best score: {ac.best_score}\")"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "# ac.results.results"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b808874",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_df = ac.test_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "# score all estimators on the test set, which we've kept aside up till now\n",
     "for est_name, scr in ac.scores.items():\n",
     "    causal_estimate = scr['estimator']\n",
     "    scr['scores']['test'] = ac.scorer.make_scores(causal_estimate, test_df, problem=ac.problem, metrics_to_report=ac.metrics_to_report)"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "255af550",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz = Visualizer(test_df=test_df, \n",
+    "                 treatment_col_name='treatment',\n",
+    "                 outcome_col_name='y_factual')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c8a08b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viz.plot_metrics_by_estimator(scores_dict=ac.scores)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cdc237a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "policy_df = ac.scores[ac.best_estimator]['scores']['test']['values']\n",
+    "\n",
+    "viz.plot_group_ate(policy_df=policy_df,\n",
+    "                   psw=ac.psw_estimator.estimator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -380,17 +579,17 @@
     "\n",
     "plt.grid()\n",
     "plt.show()\n"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "scr = ac.scores[ac.best_estimator]\n",
@@ -399,17 +598,17 @@
     "intrp.plot(feature_names=intrp.feature_names, fontsize=10)\n",
     "plt.title(f\"{ac.best_estimator}_{outcome}\")\n",
     "plt.show()\n"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -432,17 +631,17 @@
     "    plt.show()\n",
     "else: \n",
     "    print(f\"The best performing model is {ac.best_estimator} which doesn't depend on features\")\n"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "# plot out-of sample difference of outcomes between treated and untreated for the points where a model predicts positive vs negative impact\n",
@@ -469,17 +668,17 @@
     "plt.grid(True)\n",
     "plt.title(my_est.split('.')[-1])\n",
     "plt.show()"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "# plot out-of sample difference of outcomes between treated and untreated for the points where a model predicts positive vs negative impact\n",
@@ -506,13 +705,7 @@
     "plt.grid(True)\n",
     "plt.title(my_est.split('.')[-1])\n",
     "plt.show()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -528,13 +721,10 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "0d241d6181a28e0c55bf80af2e86a59829cac5369d348f4b4c4ec88c80f02ee8"
-  },
   "kernelspec": {
-   "display_name": "Python [conda env:.conda-generic3.9] *",
+   "display_name": "ref-ac",
    "language": "python",
-   "name": "conda-env-.conda-generic3.9-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -546,7 +736,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adding a "standalone" (i.e., currently not directly interacting with auto-causality) visualizer class. Mode of interaction with auto-causality tbd.

Currently implements the following plots that are floating around in various notebooks as methods:
- SHAP summary plot
- ATE/norm_erupt per estimator per split
- Group ATE plot (single & multi-treatment); single-treatment plot from notebooks extended to account for multi-treatment

Also mimics some methods from auto_causality.scorer (ate, naive_ate) as a result of being "standalone".

Open to-dos:
- [ ] decide on mode of interaction, i.e., how to integrate with auto-causality
- [ ] make plots themselves a bit nicer and allow for more flexibility/customization
- [ ] add more plots
- [ ] write tests (?)