### PR TITLE
Option to remove data from autocausality object after fit

### DIFF
--- a/tests/autocausality/test_drop_data_after_fit.py
+++ b/tests/autocausality/test_drop_data_after_fit.py
@@ -1,0 +1,80 @@
+import pytest
+import warnings
+
+from auto_causality import AutoCausality
+from auto_causality.datasets import synth_ihdp, linear_multi_dataset
+from auto_causality.params import SimpleParamService
+
+warnings.filterwarnings("ignore")  # suppress sklearn deprecation warnings for now..
+
+
+class TestDropDataAfterFit(object):
+    def test_fit_and_drop_data(self):
+        """tests if CATE model can be instantiated and fit to data"""
+
+        from auto_causality.shap import shap_values  # noqa F401
+
+        data = synth_ihdp()
+        data.preprocess_dataset()
+
+        cfg = SimpleParamService(
+            propensity_model=None,
+            outcome_model=None,
+            n_jobs=-1,
+            include_experimental=False,
+            multivalue=False,
+        )
+        estimator_list = cfg.estimator_names_from_patterns("backdoor", "all", 1)
+        # outcome = targets[0]
+        auto_causality = AutoCausality(
+            num_samples=len(estimator_list),
+            components_time_budget=5,
+            estimator_list=estimator_list,  # "all",  #
+            use_ray=False,
+            verbose=3,
+            components_verbose=2,
+            resources_per_trial={"cpu": 0.5},
+        )
+
+        auto_causality.fit(data, store_data=False)
+        auto_causality.effect(data.data)
+        auto_causality.score_dataset(data.data, "test")
+
+        # now let's test Shapley values calculation
+        for est_name, scores in auto_causality.scores.items():
+            # Dummy model doesn't support Shapley values
+            # Orthoforest shapley calc is VERY slow
+            if "Dummy" not in est_name and "Ortho" not in est_name:
+
+                print("Calculating Shapley values for", est_name)
+                shap_values(scores["estimator"], data.data[:10])
+
+        print(f"Best estimator: {auto_causality.best_estimator}")
+
+    def test_fit_and_keep_data(self):
+        data = linear_multi_dataset(10000)
+        cfg = SimpleParamService(
+            propensity_model=None,
+            outcome_model=None,
+            n_jobs=-1,
+            include_experimental=False,
+            multivalue=True,
+        )
+        estimator_list = cfg.estimator_names_from_patterns(
+            "backdoor", "all", data_rows=len(data)
+        )
+        
+        data.preprocess_dataset()
+
+        ac = AutoCausality(
+            estimator_list="all",
+            num_samples=len(estimator_list),
+            components_time_budget=5,
+        )
+        ac.fit(data)
+        # TODO add an effect() call and an effect_tt call
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])
+    # TestEndToEnd().test_endtoend_iv()


### PR DESCRIPTION
## Problem

There are memory issues with autocausality since the fitted estimator automatically stores the data after fitting. DoWhy or Scikit-Learn estimators don't do that and there is no immediate need for it.

## Proposed changes

- Add option to remove data after fitting in fit method
- also removed initialisation of autocausality with data since it is never used. Suffices and would be consistent with DoWhy / Scikit-Learn to only insert data through fit method.


In the future, will consider moving train-test-split to CausalityDataset to always keep test_df available.

## Types of changes

What types of changes does your code introduce to Auto-Causality?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
