### PR TITLE
Multi outcome fix

### DIFF
--- a/auto_causality/optimiser.py
+++ b/auto_causality/optimiser.py
@@ -275,6 +275,10 @@ class AutoCausality:
             time_budget (Optional[int]): change new time budget allocated to fit, useful for warm starts.
 
         """
+        if isinstance(data, CausalityDataset):
+            if len(data.outcomes) > 1:
+                assert outcome is not None, 'Multiple outcomes detected. Please specify outcome.'
+
         if not isinstance(data, CausalityDataset):
             assert isinstance(data, pd.DataFrame)
             data = CausalityDataset(
@@ -302,11 +306,14 @@ class AutoCausality:
             self.data.data, train_size=self._settings["train_size"], shuffle=True
         )
 
+        # dirty fix to use outcome param when multiple outcomes present
+        outcome = outcome if len(data.outcomes) > 1 else data.outcomes[0]        
+
         # smuggle propensity modifiers into common causes, filter later in component models
         self.causal_model = CausalModel(
             data=self.train_df,
             treatment=data.treatment,
-            outcome=data.outcomes[0],
+            outcome=outcome,
             common_causes=data.common_causes + data.propensity_modifiers,
             effect_modifiers=data.effect_modifiers,
             instruments=data.instruments,

--- a/auto_causality/optimiser.py
+++ b/auto_causality/optimiser.py
@@ -277,7 +277,9 @@ class AutoCausality:
         """
         if isinstance(data, CausalityDataset):
             if len(data.outcomes) > 1:
-                assert outcome is not None, 'Multiple outcomes detected. Please specify outcome.'
+                assert (
+                    outcome is not None
+                ), "Multiple outcomes detected. Please specify outcome."
 
         if not isinstance(data, CausalityDataset):
             assert isinstance(data, pd.DataFrame)
@@ -307,13 +309,13 @@ class AutoCausality:
         )
 
         # dirty fix to use outcome param when multiple outcomes present
-        outcome = outcome if len(data.outcomes) > 1 else data.outcomes[0]        
+        outcome_ = outcome if len(data.outcomes) > 1 else data.outcomes[0]
 
         # smuggle propensity modifiers into common causes, filter later in component models
         self.causal_model = CausalModel(
             data=self.train_df,
             treatment=data.treatment,
-            outcome=outcome,
+            outcome=outcome_,
             common_causes=data.common_causes + data.propensity_modifiers,
             effect_modifiers=data.effect_modifiers,
             instruments=data.instruments,
@@ -634,7 +636,6 @@ class AutoCausality:
         return self.model.effect(df, *args, **kwargs)
 
     def effect_inference(self, df, *args, **kwargs):
-
         if "Econml" in str(type(self.model)):
             # Get a list of "Inference" objects from EconML, one per treatment
             self.model.__class__.apply_multitreatment = apply_multitreatment
@@ -651,7 +652,6 @@ class AutoCausality:
             )
 
     def effect_stderr(self, df, n_bootstrap_samples=5, n_jobs=1, *args, **kwargs):
-
         if "Econml" in str(type(self.model)):
             # Get a list of "Inference" objects from EconML, one per treatment
             self.model.__class__.effect_stderr = effect_stderr


### PR DESCRIPTION
## Problem
Currently `fit` takes an `outcome` argument, but it's not being used anywhere. Instead, `outcome` in `CausalModel` is hard-coded to use `data.outcomes[0]`. When operating with multiple outcomes, this is undesired behavior and may (actually, has led) lead to confusion. 

The proposed fix does the following:

1. inside `fit` check if passed `data` instance is `CausalityDataset` (default scenario); if yes and multiple outcomes detected, `assert` that `outcome` is specified
2. ensure that `outcome` is used in `CausalModel` when multiple outcomes are present, else default to `data.outcomes[0]`

In a nutshell, this requires `outcome` in `fit` to be specified if multiple outcomes are present, else not.