### PR TITLE
Support using Hyperopt, Optuna as tuning backend; Support the use of different algorithms

### DIFF
--- a/causaltune/optimiser.py
+++ b/causaltune/optimiser.py
@@ -174,6 +174,7 @@ class CausalTune:
         self._settings["tuner"]["resources_per_trial"] = (
             resources_per_trial if resources_per_trial is not None else {"cpu": 0.5}
         )
+        self._settings["tuner"]["algo"] = None
         self._settings["try_init_configs"] = try_init_configs
         self._settings["include_experimental_estimators"] = include_experimental_estimators
 
@@ -289,7 +290,7 @@ class CausalTune:
         encoder_outcome: Optional[str] = None,
         use_ray: Optional[bool] = None,
         framework: Optional[str] = "flaml",
-        **kwargs,
+        algo = None,
     ):
         """Performs AutoML on list of causal inference estimators
         - If estimator has a search space specified in its parameters, HPO is performed on the whole model.
@@ -438,6 +439,7 @@ class CausalTune:
             self._settings["tuner"]["time_budget_s"] = (
                 2.5 * len(self.estimator_list) * self._settings["component_models"]["time_budget"]
             )
+        self._settings["tuner"]["algo"] = algo
 
         cmtb = self._settings["component_models"]["time_budget"]
 
@@ -493,7 +495,6 @@ class CausalTune:
             mode=("min" if self.metric in metrics_to_minimize() else "max"),
             framework=framework,
             **self.cfg.parse_tuner_params(self._settings["tuner"], framework),
-            **kwargs,
         )
 
         self.tuner.run()

--- a/causaltune/optimiser.py
+++ b/causaltune/optimiser.py
@@ -289,6 +289,7 @@ class CausalTune:
         encoder_outcome: Optional[str] = None,
         use_ray: Optional[bool] = None,
         framework: Optional[str] = "flaml",
+        **kwargs,
     ):
         """Performs AutoML on list of causal inference estimators
         - If estimator has a search space specified in its parameters, HPO is performed on the whole model.
@@ -492,6 +493,7 @@ class CausalTune:
             mode=("min" if self.metric in metrics_to_minimize() else "max"),
             framework=framework,
             **self.cfg.parse_tuner_params(self._settings["tuner"], framework),
+            **kwargs,
         )
 
         self.tuner.run()

--- a/causaltune/optimiser.py
+++ b/causaltune/optimiser.py
@@ -1,6 +1,6 @@
 import copy
 import warnings
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Any
 from collections import defaultdict
 import time
 
@@ -290,7 +290,7 @@ class CausalTune:
         encoder_outcome: Optional[str] = None,
         use_ray: Optional[bool] = None,
         framework: Optional[str] = "flaml",
-        algo = None,
+        algo: Any = None,
     ):
         """Performs AutoML on list of causal inference estimators
         - If estimator has a search space specified in its parameters, HPO is performed on the whole model.
@@ -310,6 +310,8 @@ class CausalTune:
             preprocess (bool): preprocess CausalityDataset if needed.
             encoder_type (Optional[str]): Categorical Encoder for preprocessing
             encoder_outcome (Optional[str]): Categorical Encoder target for preprocessing: TargetEncoder, WOE.
+            framework (Optional[str]): framework to use for HPO, choices are "flaml", "hyperopt" and "optuna".
+            algo (Optional[str]): algorithm to use for HPO, each framework has its own set of algorithms to choose from.
 
         Returns:
             None
@@ -478,7 +480,7 @@ class CausalTune:
             else []
         )
 
-        # TODO: intergrate resume
+        # TODO: intergrate resume and init cfg
         # if resume and self.results:
         #     # pull out configs and resume_scores from previous trials:
         #     for _, result in self.results.results.items():

--- a/causaltune/score/scoring.py
+++ b/causaltune/score/scoring.py
@@ -1321,7 +1321,7 @@ class Scorer:
         return out
 
     @staticmethod
-    def best_score_by_estimator(scores: Dict[str, dict], metric: str) -> Dict[str, dict]:
+    def best_score_by_estimator(scores: list[dict], metric: str) -> Dict[str, dict]:
         """Obtain best score for each estimator.
 
         Args:
@@ -1333,19 +1333,19 @@ class Scorer:
 
         """
 
-        for k, v in scores.items():
+        for v in scores:
             if "estimator_name" not in v:
                 raise ValueError(
                     f"Malformed scores dict, 'estimator_name' field missing " f"in{k}, {v}"
                 )
 
         estimator_names = sorted(
-            list(set([v["estimator_name"] for v in scores.values() if "estimator_name" in v]))
+            list(set([v["estimator_name"] for v in scores if "estimator_name" in v]))
         )
         best = {}
         for name in estimator_names:
             est_scores = [
-                v for v in scores.values() if "estimator_name" in v and v["estimator_name"] == name
+                v for v in scores if "estimator_name" in v and v["estimator_name"] == name
             ]
             best[name] = (
                 min(est_scores, key=lambda x: x[metric])

--- a/causaltune/search/params.py
+++ b/causaltune/search/params.py
@@ -169,17 +169,25 @@ class SimpleParamService:
     @staticmethod
     def parse_tuner_params(params: dict, framework: str) -> dict:
         if framework == "flaml":
-            return params
+            return {
+                "num_samples": params["num_samples"],
+                "time_budget_s": params["time_budget_s"],
+                "verbose": params["verbose"],
+                "resources_per_trial": params["resources_per_trial"],
+                "search_alg": params["algo"],
+            }
         elif framework == "hyperopt":
             return {
                 "max_evals": params["num_samples"] if params["num_samples"] != -1 else None,
                 "timeout": params["time_budget_s"],
                 "verbose": params["verbose"],
+                "algo": params["algo"],
             }
         elif framework == "optuna":
             return {
                 "n_trials": params["num_samples"] if params["num_samples"] != -1 else None,
                 "timeout": params["time_budget_s"],
+                "sampler": params["algo"],
             }
         else:
             raise ValueError(f"Framework {framework} not supported")

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setup(
         "wise-pizza",
         "seaborn",
         "category_encoders==2.6.3",
+        "hiertunehub",
+        "hyperopt",
+        "optuna"
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Problem

- Causaltune currently only supports FLAML as its hyperparamter optimization library. However, there are two widely used hyperparameter optimization libraries that causaltune does not support: [Hyperopt](https://github.com/hyperopt/hyperopt) and [Optuna](https://github.com/optuna/optuna).

## Proposed changes

- Introduce [HierTuneHub](https://github.com/ItsYikunJiang/HierTuneHub) as the unified interface for parsing search space and dealing with different hyperparamter optimization libraries.
- Add support for Hyperopt and Optuna as optimization backends for causaltune. 
- Enable users to choose which algorithm they want to use during the hyperparameter optimization process.

Note that it will bring breaking change to causaltune. `CausalTune.fit()` can not resume and init config can not be passed into the tuning backend (it can be fixed later).

## Types of changes

What types of changes does your code introduce to causaltune?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
